### PR TITLE
add redirect_uri for windows phone shoop app

### DIFF
--- a/Shoot/configuration/shoot-realm.json
+++ b/Shoot/configuration/shoot-realm.json
@@ -59,7 +59,7 @@
     }],
     "oauthClients" : [ {
         "name" : "shoot-third-party",
-        "redirectUris" : [ "org.aerogear.Shoot://oauth2Callback", "http://oauth2callback" ],
+        "redirectUris" : [ "org.aerogear.Shoot://oauth2Callback", "http://oauth2callback", "org.aerogear.shoot:/oauth2Callback" ],
         "webOrigins" : [ ],
         "enabled" : true,
         "publicClient" : true


### PR DESCRIPTION
@edewit it will be easier to have the windows redirect_uri directly in the shoot-realm config file, to avoid one manual config step.