### PR TITLE
OpenShift instructions

### DIFF
--- a/Authentication/README.md
+++ b/Authentication/README.md
@@ -35,3 +35,11 @@ curl -v \
 
      mvn clean install
      mvn wildfly:deploy
+
+### Deploy on OpenShift
+
+To follow the instructions below, you need [rhc](https://developers.openshift.com/en/managing-client-tools.html) installed.
+
+     rhc app create bacon jboss-wildfly-8
+
+The ```bacon``` demo app is then available in [OpenShift online](http://bacon-corinnekrych.rhcloud.com/rest/grocery/bacons).


### PR DESCRIPTION
Given that some ios cookbook recipe used this [app deployed on OpenShift](https://github.com/aerogear/aerogear-ios-cookbook/blob/master/Authentication/Authentication/Network.swift#L25). 
Having the deployment instructions is handy.