### PR TITLE
minimal S for Keycloak redirect_uri

### DIFF
--- a/Shoot/configuration/shoot-realm.json
+++ b/Shoot/configuration/shoot-realm.json
@@ -59,7 +59,7 @@
     }],
     "oauthClients" : [ {
         "name" : "shoot-third-party",
-        "redirectUris" : [ "org.aerogear.Shoot://oauth2Callback", "http://oauth2callback", "org.aerogear.shoot:/oauth2Callback" ],
+        "redirectUris" : [ "org.aerogear.shoot://oauth2Callback", "http://oauth2callback", "org.aerogear.shoot:/oauth2Callback" ],
         "webOrigins" : [ ],
         "enabled" : true,
         "publicClient" : true


### PR DESCRIPTION
@edewit it seems with KC19.1 redirect_uri should not have uppercase