### PR TITLE
Make SharedShoot redirect url lowercase

### DIFF
--- a/Shoot/configuration/shoot-realm.json
+++ b/Shoot/configuration/shoot-realm.json
@@ -65,7 +65,7 @@
         "publicClient" : true
     }, {
         "name" : "sharedshoot-third-party",
-        "redirectUris" : [ "org.aerogear.SharedShoot://oauth2Callback", "http://oauth2callback" ],
+        "redirectUris" : [ "org.aerogear.sharedshoot://oauth2Callback", "http://oauth2callback" ],
         "webOrigins" : [ ],
         "claims" : {
             "name" : true,


### PR DESCRIPTION
SharedShoot iOS cookbook wasn't working because of this.